### PR TITLE
Add broken test for tool param inheritance

### DIFF
--- a/vortex/tests/fixtures/params-specific.yml
+++ b/vortex/tests/fixtures/params-specific.yml
@@ -1,0 +1,38 @@
+global:
+  default_inherits: default
+
+tools:
+  default:
+    cores: 2
+    mem: cores * 3
+    env:
+      TEST_JOB_SLOTS: "{cores}"
+    params:
+      native_spec: "--mem {mem} --cores {cores}"
+    scheduling:
+      require: []
+      prefer:
+        - general
+      accept:
+      reject:
+        - pulsar
+  grappa:
+    params:
+      earth: 'mostly harmless'
+    env:
+      JAVA_MEM: 42
+
+destinations:
+  local:
+    cores: 4
+    mem: 16
+    scheduling:
+      prefer:
+        - general
+  k8s_environment:
+    cores: 16
+    mem: 64
+    gpus: 2
+    scheduling:
+      prefer:
+        - pulsar

--- a/vortex/tests/test_params_specific.py
+++ b/vortex/tests/test_params_specific.py
@@ -1,0 +1,29 @@
+import os
+import unittest
+from vortex.rules import gateway
+from . import mock_galaxy
+
+
+class TestParamsSpecific(unittest.TestCase):
+
+    @staticmethod
+    def _map_to_destination(tool, user):
+        galaxy_app = mock_galaxy.App()
+        job = mock_galaxy.Job()
+        vortex_config = os.path.join(os.path.dirname(__file__), 'fixtures/params-specific.yml')
+        gateway.ACTIVE_DESTINATION_MAPPER = None
+        return gateway.map_tool_to_destination(galaxy_app, job, tool, user, vortex_config_files=[vortex_config])
+
+    def test_default_does_not_inherit_descendant_params(self):
+        tool = mock_galaxy.Tool('bwa')
+        user = mock_galaxy.User('ford', 'prefect@vortex.org')
+
+        destination = self._map_to_destination(tool, user)
+        self.assertTrue('earth' not in destination.params)
+
+    def test_default_does_not_inherit_descendant_env(self):
+        tool = mock_galaxy.Tool('agrajag')
+        user = mock_galaxy.User('ford', 'prefect@vortex.org')
+
+        destination = self._map_to_destination(tool, user)
+        self.assertTrue('JAVA_MEM' not in [e['name'] for e in destination.env])


### PR DESCRIPTION
Hi @nuwang, I noticed something odd where if I put 'docker_enabled: true' in a tool's destination parameters it would come up in the destination parameters for other tools.  I could add this to the inheritance test case.