### PR TITLE
put reload def within setup def so that it has vortex_config_files

### DIFF
--- a/vortex/rules/gateway.py
+++ b/vortex/rules/gateway.py
@@ -28,6 +28,7 @@ def setup_destination_mapper(app, vortex_config_files):
     job_rule_watcher = get_watcher(app.config, 'watch_job_rules', monitor_what_str='job rules')
 
     def reload_destination_mapper(path=None):
+        # reload all config files when one file changes to preserve order of loading the files
         global ACTIVE_DESTINATION_MAPPER
         ACTIVE_DESTINATION_MAPPER = load_destination_mapper(vortex_config_files, reload=True)
 


### PR DESCRIPTION
there's a bug in the setup on dev when a watched rule file changes:

```
Oct 22 01:48:39 dev uwsgi[3835532]: vortex.rules.gateway INFO 2021-10-22 01:48:39,692 [pN:main.job-handlers.2,p:3835532,w:0,m:2,tN:Thread-3] reloading vortex rules from: /mnt/galaxy/config/vortex_rules_local.yml
Oct 22 01:48:39 dev uwsgi[3835532]: Exception in thread Thread-3:
Oct 22 01:48:39 dev uwsgi[3835532]: Traceback (most recent call last):
Oct 22 01:48:39 dev uwsgi[3835532]:   File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
Oct 22 01:48:39 dev uwsgi[3835532]:     self.run()
Oct 22 01:48:39 dev uwsgi[3835532]:   File "/mnt/galaxy/venv/lib/python3.8/site-packages/watchdog/observers/api.py", line 199, in run
Oct 22 01:48:39 dev uwsgi[3835532]:     self.dispatch_events(self.event_queue, self.timeout)
Oct 22 01:48:39 dev uwsgi[3835532]:   File "/mnt/galaxy/venv/lib/python3.8/site-packages/watchdog/observers/api.py", line 372, in dispatch_events
Oct 22 01:48:39 dev uwsgi[3835532]:     handler.dispatch(event)
Oct 22 01:48:39 dev uwsgi[3835532]:   File "/mnt/galaxy/venv/lib/python3.8/site-packages/watchdog/events.py", line 271, in dispatch
Oct 22 01:48:39 dev uwsgi[3835532]:     self.on_any_event(event)
Oct 22 01:48:39 dev uwsgi[3835532]:   File "/mnt/galaxy/galaxy-app/lib/galaxy/util/watcher.py", line 135, in on_any_event
Oct 22 01:48:39 dev uwsgi[3835532]:     self._handle(event)
Oct 22 01:48:39 dev uwsgi[3835532]:   File "/mnt/galaxy/galaxy-app/lib/galaxy/util/watcher.py", line 173, in _handle
Oct 22 01:48:39 dev uwsgi[3835532]:     callback(path=path)
Oct 22 01:48:39 dev uwsgi[3835532]:   File "/mnt/galaxy/venv/lib/python3.8/site-packages/vortex/rules/gateway.py", line 28, in reload_destination_mapper
Oct 22 01:48:39 dev uwsgi[3835532]:     ACTIVE_DESTINATION_MAPPER = load_destination_mapper(path, reload=True)
Oct 22 01:48:39 dev uwsgi[3835532]:   File "/mnt/galaxy/venv/lib/python3.8/site-packages/vortex/rules/gateway.py", line 18, in load_destination_mapper
Oct 22 01:48:39 dev uwsgi[3835532]:     current_loader = VortexConfigLoader.from_url_or_path(vortex_config_file)
Oct 22 01:48:39 dev uwsgi[3835532]:   File "/mnt/galaxy/venv/lib/python3.8/site-packages/vortex/core/loader.py", line 117, in from_url_or_path
Oct 22 01:48:39 dev uwsgi[3835532]:     with requests.get(url_or_path) as r:
Oct 22 01:48:39 dev uwsgi[3835532]:   File "/mnt/galaxy/venv/lib/python3.8/site-packages/requests/api.py", line 76, in get
Oct 22 01:48:39 dev uwsgi[3835532]:     return request('get', url, params=params, **kwargs)
Oct 22 01:48:39 dev uwsgi[3835532]:   File "/mnt/galaxy/venv/lib/python3.8/site-packages/requests/api.py", line 61, in request
Oct 22 01:48:39 dev uwsgi[3835532]:     return session.request(method=method, url=url, **kwargs)
Oct 22 01:48:39 dev uwsgi[3835532]:   File "/mnt/galaxy/venv/lib/python3.8/site-packages/requests/sessions.py", line 528, in request
Oct 22 01:48:39 dev uwsgi[3835532]:     prep = self.prepare_request(req)
Oct 22 01:48:39 dev uwsgi[3835532]:   File "/mnt/galaxy/venv/lib/python3.8/site-packages/requests/sessions.py", line 456, in prepare_request
Oct 22 01:48:39 dev uwsgi[3835532]:     p.prepare(
Oct 22 01:48:39 dev uwsgi[3835532]:   File "/mnt/galaxy/venv/lib/python3.8/site-packages/requests/models.py", line 316, in prepare
Oct 22 01:48:39 dev uwsgi[3835532]:     self.prepare_url(url, params)
Oct 22 01:48:39 dev uwsgi[3835532]:   File "/mnt/galaxy/venv/lib/python3.8/site-packages/requests/models.py", line 390, in prepare_url
Oct 22 01:48:39 dev uwsgi[3835532]:     raise MissingSchema(error)
Oct 22 01:48:39 dev uwsgi[3835532]: requests.exceptions.MissingSchema: Invalid URL '/': No schema supplied. Perhaps you meant http:///?
```

because load_destination_mapper is looping through a string `/mnt/galaxy/config/vortex_local.yml`.