### PR TITLE
test user spec for higher/lower number of cores than general case

### DIFF
--- a/tests/fixtures/scenario-usegalaxy-dev.yml
+++ b/tests/fixtures/scenario-usegalaxy-dev.yml
@@ -44,6 +44,17 @@ users:
       - match: |
           False
         fail: "You cannot have more than 4 high-mem jobs running concurrently"
+  misa@krikkit.net:
+    rules:
+      - match: |
+          'bwa_mem' in tool.id
+        cores: 1
+  lisa@krikkit.net:
+    rules:
+      - match: |
+          'bwa_mem' in tool.id
+        cores: 16
+
 destinations:
   slurm:
     cores: 4


### PR DESCRIPTION
One failing test and one that passes:
First test case fails: if a user is assigned 1 core, the mem remains as if they were using 2
Second test case passes because the minimum of tool, user rules is used.  At the moment GA does promote some users, but I don't know what the general feeling is about whether this is needed.

I've just tacked this on to the usergalaxy_au_dev scenario.. I can think more about how to fit this into the tests more naturally
 