### PR TITLE
add functions from galaxys dynamic_tool_destinations.py for making argument-based rules

### DIFF
--- a/tests/fixtures/mapping-rule-argument-based.yml
+++ b/tests/fixtures/mapping-rule-argument-based.yml
@@ -1,0 +1,36 @@
+global:
+  default_inherits: default
+
+tools:
+  default:
+    cores: 2
+    mem: cores * 3
+    env:
+      TEST_JOB_SLOTS: "{cores}"
+    params:
+      native_spec: "--mem {mem} --cores {cores}"
+    scheduling:
+      accept:
+        - general
+  limbo:
+    rules:
+      - match: |
+          helpers.job_args_match(job, app, {'input_opts': {'db_selector': 'db'}})
+        scheduling:
+          prefer:
+            - pulsar
+
+destinations:
+  local:
+    cores: 4
+    mem: 16
+    scheduling:
+      prefer:
+        - general
+  k8s_environment:
+    cores: 16
+    mem: 64
+    gpus: 2
+    scheduling:
+      require:
+        - pulsar

--- a/tests/mock_galaxy.py
+++ b/tests/mock_galaxy.py
@@ -19,6 +19,11 @@ class Job:
         self.input_datasets.append(dataset)
 
 
+    def get_param_values(self, app):
+        return self.param_values
+
+
+
 class DatasetAssociation:
     def __init__(self, name, dataset):
         self.name = name

--- a/tests/test_mapper_rules.py
+++ b/tests/test_mapper_rules.py
@@ -8,20 +8,17 @@ from . import mock_galaxy
 from galaxy.jobs.mapper import JobMappingException
 from galaxy.jobs.mapper import JobNotReadyException
 
-class MockGalaxyJob(mock_galaxy.Job):
-    def get_param_values(self, app):
-        return self.parameters if self.parameters else {}
 
 class TestMapperRules(unittest.TestCase):
 
     @staticmethod
-    def _map_to_destination(tool, user, datasets, parameters = {}, vortex_config_path=None):
+    def _map_to_destination(tool, user, datasets, param_values=None, vortex_config_path=None):
         galaxy_app = mock_galaxy.App()
-        job = MockGalaxyJob()
+        job = mock_galaxy.Job()
         for d in datasets:
             job.add_input_dataset(d)
-        if parameters:
-            job.parameters = parameters
+        if param_values:
+            job.param_values = param_values
         vortex_config = vortex_config_path or os.path.join(os.path.dirname(__file__), 'fixtures/mapping-rules.yml')
         gateway.ACTIVE_DESTINATION_MAPPER = None
         return gateway.map_tool_to_destination(galaxy_app, job, tool, user, vortex_config_files=[vortex_config])
@@ -116,14 +113,14 @@ class TestMapperRules(unittest.TestCase):
         user = mock_galaxy.User('gag', 'gaghalfrunt@vortex.org')
         vortex_config = os.path.join(os.path.dirname(__file__), 'fixtures/mapping-rule-argument-based.yml')
         datasets = [mock_galaxy.DatasetAssociation("test", mock_galaxy.Dataset("test.txt", file_size=7*1024**3))]
-        parameters = {
+        param_values = {
             'output_style': 'flat',
             'colour': {'nighttime': 'blue'},
             'input_opts': {'tabs_to_spaces': False, 'db_selector': 'db'},
         }
-        destination = self._map_to_destination(tool, user, datasets, parameters, vortex_config_path=vortex_config)
+        destination = self._map_to_destination(tool, user, datasets, param_values, vortex_config_path=vortex_config)
         self.assertEqual(destination.id, 'k8s_environment')
 
-        parameters['input_opts']['db_selector'] = 'history'
-        destination = self._map_to_destination(tool, user, datasets, parameters, vortex_config_path=vortex_config)
+        param_values['input_opts']['db_selector'] = 'history'
+        destination = self._map_to_destination(tool, user, datasets, param_values, vortex_config_path=vortex_config)
         self.assertEqual(destination.id, 'local')

--- a/vortex/core/helpers.py
+++ b/vortex/core/helpers.py
@@ -29,7 +29,7 @@ def weighted_random_sampling(destinations):
     return random.choices(destinations, weights=rankings, k=len(destinations))
 
 
-def get_keys_from_dict(dl, keys_list):
+def __get_keys_from_dict(dl, keys_list):
     # This function builds a list using the keys from nest dictionaries
     # (copied from galaxyproject/galaxy lib/galaxy/jobs/dynamic_tool_destination.py)
     if isinstance(dl, dict):

--- a/vortex/core/helpers.py
+++ b/vortex/core/helpers.py
@@ -27,3 +27,37 @@ def input_size(job):
 def weighted_random_sampling(destinations):
     rankings = [(d.params.get('weight', 1) if d.params else 1) for d in destinations]
     return random.choices(destinations, weights=rankings, k=len(destinations))
+
+
+def get_keys_from_dict(dl, keys_list):
+    # This function builds a list using the keys from nest dictionaries
+    # (copied from galaxyproject/galaxy lib/galaxy/jobs/dynamic_tool_destination.py)
+    if isinstance(dl, dict):
+        keys_list.extend(dl.keys())
+        for x in dl.values():
+            get_keys_from_dict(x, keys_list)
+    elif isinstance(dl, list):
+        for x in dl:
+            get_keys_from_dict(x, keys_list)
+
+
+def job_arguments_match(job, app, arguments):
+    # Check whether a dictionary of arguments matches a job's parameters.  This code is
+    # from galaxyproject/galaxy lib/galaxy/jobs/dynamic_tool_destination.py
+    if not arguments or not isinstance(arguments, dict):
+        return False
+    options = job.get_param_values(app)
+    matched = True
+    # check if the args in the config file are available
+    for arg in arguments:
+        arg_dict = {arg: arguments[arg]}
+        arg_keys_list = []
+        get_keys_from_dict(arg_dict, arg_keys_list)
+        try:
+            options_value = reduce(dict.__getitem__, arg_keys_list, options)
+            arg_value = reduce(dict.__getitem__, arg_keys_list, arg_dict)
+            if (arg_value != options_value):
+                matched = False
+        except KeyError:
+            matched = False
+    return matched

--- a/vortex/core/helpers.py
+++ b/vortex/core/helpers.py
@@ -35,24 +35,24 @@ def __get_keys_from_dict(dl, keys_list):
     if isinstance(dl, dict):
         keys_list.extend(dl.keys())
         for x in dl.values():
-            get_keys_from_dict(x, keys_list)
+            __get_keys_from_dict(x, keys_list)
     elif isinstance(dl, list):
         for x in dl:
-            get_keys_from_dict(x, keys_list)
+            __get_keys_from_dict(x, keys_list)
 
 
 def job_args_match(job, app, args):
     # Check whether a dictionary of arguments matches a job's parameters.  This code is
     # from galaxyproject/galaxy lib/galaxy/jobs/dynamic_tool_destination.py
-    if not arguments or not isinstance(arguments, dict):
+    if not args or not isinstance(args, dict):
         return False
     options = job.get_param_values(app)
     matched = True
     # check if the args in the config file are available
-    for arg in arguments:
-        arg_dict = {arg: arguments[arg]}
+    for arg in args:
+        arg_dict = {arg: args[arg]}
         arg_keys_list = []
-        get_keys_from_dict(arg_dict, arg_keys_list)
+        __get_keys_from_dict(arg_dict, arg_keys_list)
         try:
             options_value = reduce(dict.__getitem__, arg_keys_list, options)
             arg_value = reduce(dict.__getitem__, arg_keys_list, arg_dict)

--- a/vortex/core/helpers.py
+++ b/vortex/core/helpers.py
@@ -41,7 +41,7 @@ def get_keys_from_dict(dl, keys_list):
             get_keys_from_dict(x, keys_list)
 
 
-def job_arguments_match(job, app, arguments):
+def job_args_match(job, app, args):
     # Check whether a dictionary of arguments matches a job's parameters.  This code is
     # from galaxyproject/galaxy lib/galaxy/jobs/dynamic_tool_destination.py
     if not arguments or not isinstance(arguments, dict):


### PR DESCRIPTION
Hi @nuwang, I need to write a test for this.  Most lines of code here are straight from galaxy.  I can't think of a better way to do it.

If a jobs arguments are {'input_group1': {'A': 'B', 'C': {'D': 'E'}}}
then {'input_group1': {'A': 'B'}} would match, {'input_group1': {'C': {'D': 'E'}}} would match,
{'input_group1': {'A': 'G'}} would not match, {'input_group1': 'A': 'B', 'C': {'D': 'X'}}} would not match
