### PR TITLE
Replace deprecated pydantic class Config with ConfigDict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ maintainers = [
 ]
 version = "3.2.0"
 dependencies = [
+    "pydantic>=2",
     "cachetools>=3.1.0",
     "types-cachetools",
     "watchdog",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import os
+import tempfile
+
 import pytest
 
 from tpv.rules import gateway
@@ -9,6 +12,10 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
+    # Give each xdist worker its own mypy cache to avoid concurrent cache corruption
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+    if worker_id:
+        os.environ["MYPY_CACHE_DIR"] = os.path.join(tempfile.gettempdir(), f".mypy_cache_{worker_id}")
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -70,7 +70,7 @@ class TestEntity(unittest.TestCase):
         # create a destination
         destination = loader.config.destinations["k8s_environment"]
         # serialize the destination
-        serialized_destination = destination.dict()
+        serialized_destination = destination.model_dump()
         # deserialize the same destination
         deserialized_destination = Destination(evaluator=loader, **serialized_destination)
         # make sure the deserialized destination is the same as the original
@@ -83,7 +83,7 @@ class TestEntity(unittest.TestCase):
         # create a tool
         tool = loader.config.tools["limbo"]
         # serialize the tool
-        serialized_tool = tool.dict()
+        serialized_tool = tool.model_dump()
         # deserialize the same tool
         deserialized_tool = Tool(evaluator=loader, **serialized_tool)
         # make sure the deserialized tool is the same as the original

--- a/tpv/commands/dryrunner.py
+++ b/tpv/commands/dryrunner.py
@@ -25,9 +25,9 @@ class TPVDryRunner:
         if tpv_confs:
             self.tpv_config_files = tpv_confs
         else:
-            tpv_config_list: list[str] = self.galaxy_app.job_config.get_destination(  # type: ignore[no-untyped-call]
-                "tpv_dispatcher"
-            ).params["tpv_config_files"]
+            tpv_config_list: list[str] = self.galaxy_app.job_config.get_destination("tpv_dispatcher").params[
+                "tpv_config_files"
+            ]
             self.tpv_config_files = self.resolve_relative_config_paths(tpv_config_list, job_conf)
 
     @staticmethod

--- a/tpv/commands/linter.py
+++ b/tpv/commands/linter.py
@@ -80,7 +80,7 @@ class TPVConfigLinter(object):
                     )
 
             # Recurse into fields
-            for field_name, _ in obj.model_fields.items():
+            for field_name, _ in type(obj).model_fields.items():
                 value = getattr(obj, field_name)
                 self.check_for_extra_fields_recurse(value, f"{path}.{field_name}")
 

--- a/tpv/commands/mypychecker.py
+++ b/tpv/commands/mypychecker.py
@@ -166,7 +166,7 @@ def gather_fields_from_entity(
     context_vars = getattr(entity, "context") or {}
     infer_context_var_type(context_vars_container, context_vars)
     code_snippets = []
-    fields_dict = getattr(entity, "model_fields")
+    fields_dict = type(entity).model_fields
 
     for field_name, field_info in fields_dict.items():
         # field_info.metadata is typically a tuple
@@ -240,7 +240,6 @@ def type_check_code(loader: TPVConfigLoader, preserve_temp_code: bool) -> tuple[
         tmp_file.flush()
 
         mypy_args = [
-            # "--no-incremental", # https://stackoverflow.com/a/65223004/10971151
             tmp_filename,
         ]
         stdout, stderr, exit_code = mypy.api.run(mypy_args)

--- a/tpv/commands/shell.py
+++ b/tpv/commands/shell.py
@@ -87,9 +87,7 @@ def tpv_dump_config(args: Any) -> None:
 
         galaxy_app = mock_galaxy.App(job_conf=args.job_conf, create_model=True)
         config_files = TPVDryRunner.resolve_relative_config_paths(
-            galaxy_app.job_config.get_destination("tpv_dispatcher").params[  # type: ignore[no-untyped-call]
-                "tpv_config_files"
-            ],
+            galaxy_app.job_config.get_destination("tpv_dispatcher").params["tpv_config_files"],
             args.job_conf,
         )
     if not config_files:

--- a/tpv/core/entities.py
+++ b/tpv/core/entities.py
@@ -16,7 +16,7 @@ from typing import (
 )
 
 from galaxy import util as galaxy_util
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic.json_schema import SkipJsonSchema
 
 # xref: https://github.com/python/mypy/issues/12664
@@ -100,8 +100,7 @@ class SchedulingTags(BaseModel):
     accept: list[str] | None = Field(default_factory=lambda: list())
     reject: list[str] | None = Field(default_factory=lambda: list())
 
-    class Config:
-        extra = "allow"
+    model_config = ConfigDict(extra="allow")
 
     @model_validator(mode="after")
     def check_duplicates(self) -> Self:
@@ -233,9 +232,7 @@ class SchedulingTags(BaseModel):
 
 
 class Entity(BaseModel):
-    class Config:
-        arbitrary_types_allowed = True
-        extra = "allow"
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
 
     merge_order: ClassVar[int] = 0
     # assign a dummy value for now, so pydantic does not treat this as a required field
@@ -726,17 +723,14 @@ class Destination(EntityWithRules):
 
 
 class GlobalConfig(BaseModel):
-    class Config:
-        extra = "allow"
+    model_config = ConfigDict(extra="allow")
 
     default_inherits: str | None = None
     context: dict[str, Any] = Field(default_factory=lambda: dict())
 
 
 class TPVConfig(BaseModel):
-    class Config:
-        arbitrary_types_allowed = True
-        extra = "allow"
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
 
     global_config: GlobalConfig = Field(alias="global", default_factory=GlobalConfig)
     evaluator: SkipJsonSchema[TPVCodeEvaluator | None] = Field(exclude=True, default=None)

--- a/tpv/core/entities.py
+++ b/tpv/core/entities.py
@@ -486,11 +486,6 @@ class Entity(BaseModel):
         kwargs.setdefault("by_alias", True)
         return super().model_dump(**kwargs)
 
-    def dict(self, **kwargs: Any) -> dict[str, Any]:
-        # by_alias is set to True to use the field aliases during serialization
-        kwargs.setdefault("by_alias", True)
-        return super().dict(**kwargs)
-
 
 class Rule(Entity):
     rule_counter: ClassVar[int] = 0

--- a/tpv/core/mapper.py
+++ b/tpv/core/mapper.py
@@ -211,10 +211,10 @@ class EntityToDestinationMapper(object):
             id=destination.dest_name,
             tags=destination.handler_tags,
             runner=destination.runner,
-            params=destination.params,
-            env=destination.env,
-            resubmit=list(destination.resubmit.values()),
-        )  # type: ignore[no-untyped-call]
+            params=destination.params or {},
+            env=destination.env or [],
+            resubmit=list(destination.resubmit.values()),  # type: ignore[arg-type]
+        )
 
     def _find_matching_entities(
         self, context: dict[str, Any], tool: GalaxyTool, user: GalaxyUser | None


### PR DESCRIPTION
## Summary
- Replace the deprecated pydantic V1 `class Config` inner class pattern with the V2 `model_config = ConfigDict(...)` syntax in all 4 BaseModel subclasses (`SchedulingTags`, `Entity`, `GlobalConfig`, `TPVConfig`)
- Add `pydantic>=2` as an explicit dependency in `pyproject.toml`

This eliminates `PydanticDeprecatedSince20` warnings at import time, allowing Galaxy to make pydantic deprecation warnings errors.

Fixes #190