### PR TITLE
Tighten trusted-publishing blast radius: split build/publish + dedicated env

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,7 +24,7 @@ jobs:
         python3 setup.py sdist bdist_wheel
         uvx twine check dist/*
         ls -l dist
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: packages
         path: dist/
@@ -38,7 +38,7 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         name: packages
         path: dist

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,13 +6,13 @@ on:
     tags:
       - '*'
 jobs:
-  build-n-publish:
-    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+  build_packages:
+    name: Build Python 🐍 distributions 📦
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
@@ -24,6 +24,23 @@ jobs:
         python3 setup.py sdist bdist_wheel
         uvx twine check dist/*
         ls -l dist
+    - uses: actions/upload-artifact@v4
+      with:
+        name: packages
+        path: dist/
+
+  publish:
+    name: Publish distribution 📦 to PyPI
+    needs: [build_packages]
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        name: packages
+        path: dist
     - name: Publish distribution 📦 to PyPI
-      if: github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Same pattern as CloudVE/cloudbridge#332, applied to TPV's deploy workflow.

## Summary
- Split `deploy.yaml` into two jobs: `build_packages` builds the sdist/wheel and uploads them as an artifact, `publish` downloads them and uploads to PyPI. Only `publish` requests `id-token: write`, so the OIDC token can no longer be minted during the build step.
- Pin the `publish` job to a dedicated `pypi` GitHub environment so the trusted-publisher binding (and any future protection rules / environment-scoped secrets) is isolated to that environment rather than the whole repo.
- Moves the `release`-only condition from the publish step to the publish job (preserves prior behavior: build always runs on tag push; publish only runs on a published release).

## Required maintainer action
PyPI atrusted-publisher configuration already updated and  github pypi environment created
