### PR TITLE
Add a explain on failure option to log scheduling trace for job mapping failures

### DIFF
--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -1,7 +1,5 @@
-import logging
 import os
 import unittest
-from contextlib import contextmanager
 from unittest.mock import MagicMock
 
 import yaml
@@ -503,26 +501,6 @@ class TestDryRunExplain(unittest.TestCase):
         self.assertIsNone(runner.tool)
 
 
-@contextmanager
-def _capture_logs(logger_name, level=logging.WARNING):
-    """Capture log records while keeping propagation enabled so --log-cli-level shows them."""
-    records = []
-
-    class _Handler(logging.Handler):
-        def emit(self, record):
-            records.append(record)
-
-    logger = logging.getLogger(logger_name)
-    handler = _Handler(level)
-    old_level = logger.level
-    logger.setLevel(level)
-    logger.addHandler(handler)
-    try:
-        yield records
-    finally:
-        logger.removeHandler(handler)
-        logger.setLevel(old_level)
-
 
 class TestGatewayExplainOnFailure(unittest.TestCase):
     """Tests for the tpv_explain_on_failure gateway config option."""
@@ -546,19 +524,18 @@ class TestGatewayExplainOnFailure(unittest.TestCase):
 
     def test_no_log_when_param_not_set(self):
         """No warning is logged on failure when tpv_explain_on_failure is not configured."""
-        with _capture_logs("tpv.rules.gateway") as records:
+        with self.assertNoLogs("tpv.rules.gateway", level="WARNING"):
             with self.assertRaises(JobMappingException):
                 self._call_gateway("unschedulable_tool")
-        self.assertEqual(len(records), 0)
 
     def test_logs_trace_on_mapping_failure(self):
         """A WARNING containing the scheduling trace is logged when tpv_explain_on_failure=true and mapping fails."""
         referrer = JobDestination(id="tpv_dispatcher", params={"tpv_explain_on_failure": True})
-        with _capture_logs("tpv.rules.gateway") as records:
+        with self.assertLogs("tpv.rules.gateway", level="WARNING") as cm:
             with self.assertRaises(JobMappingException):
                 self._call_gateway("unschedulable_tool", referrer=referrer)
-        self.assertEqual(len(records), 1)
-        trace = records[0].getMessage()
+        self.assertEqual(len(cm.records), 1)
+        trace = cm.records[0].getMessage()
         self.assertIn("TPV SCHEDULING DECISION TRACE", trace)
         self.assertIn("REJECTED", trace)
         self.assertIn("tag mismatch", trace)
@@ -567,16 +544,14 @@ class TestGatewayExplainOnFailure(unittest.TestCase):
     def test_no_log_on_successful_mapping(self):
         """No warning is logged when tpv_explain_on_failure=true but mapping succeeds."""
         referrer = JobDestination(id="tpv_dispatcher", params={"tpv_explain_on_failure": True})
-        with _capture_logs("tpv.rules.gateway") as records:
+        with self.assertNoLogs("tpv.rules.gateway", level="WARNING"):
             destination = self._call_gateway("bwa", referrer=referrer)
         self.assertIsNotNone(destination)
-        self.assertEqual(len(records), 0)
 
     def test_explicit_collector_not_logged_by_gateway(self):
         """When an explicit explain_collector is passed (dry-run path), the gateway does not log on failure."""
         collector = ExplainCollector()
-        with _capture_logs("tpv.rules.gateway") as records:
+        with self.assertNoLogs("tpv.rules.gateway", level="WARNING"):
             with self.assertRaises(JobMappingException):
                 self._call_gateway("unschedulable_tool", explain_collector=collector)
-        self.assertEqual(len(records), 0)
         self.assertTrue(len(collector.steps) > 0)

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -1,13 +1,16 @@
 import os
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import yaml
+from galaxy.jobs import JobDestination
 from galaxy.jobs.mapper import JobMappingException
 
 from tpv.commands.dryrunner import TPVDryRunner
+from tpv.commands.test import mock_galaxy
 from tpv.core.entities import SchedulingTags
 from tpv.core.explain import ExplainCollector, ExplainPhase
+from tpv.rules import gateway
 
 
 class TestExplainCollectorUnit(unittest.TestCase):
@@ -496,3 +499,59 @@ class TestDryRunExplain(unittest.TestCase):
             tpv_confs=[self._fixture_path("mapping-basic.yml")],
         )
         self.assertIsNone(runner.tool)
+
+
+class TestGatewayExplainOnFailure(unittest.TestCase):
+    """Tests for the tpv_explain_on_failure gateway config option."""
+
+    @staticmethod
+    def _fixture_path(name):
+        return os.path.join(os.path.dirname(__file__), f"fixtures/{name}")
+
+    def _call_gateway(self, tool_id, referrer=None, explain_collector=None):
+        gateway.ACTIVE_DESTINATION_MAPPERS = {}
+        app = mock_galaxy.App(job_conf=self._fixture_path("job_conf.yml"))
+        tool = mock_galaxy.Tool(tool_id)
+        job = mock_galaxy.Job()
+        user = mock_galaxy.User("gargravarr", "fairycake@vortex.org")
+        return gateway.map_tool_to_destination(
+            app, job, tool, user,
+            referrer=referrer,
+            tpv_config_files=[self._fixture_path("mapping-basic.yml")],
+            explain_collector=explain_collector,
+        )
+
+    def test_no_log_when_param_not_set(self):
+        """No warning is logged on failure when tpv_explain_on_failure is not configured."""
+        with patch.object(gateway.log, "warning") as mock_warning:
+            with self.assertRaises(JobMappingException):
+                self._call_gateway("unschedulable_tool")
+            mock_warning.assert_not_called()
+
+    def test_logs_trace_on_mapping_failure(self):
+        """A WARNING containing the scheduling trace is logged when tpv_explain_on_failure=true and mapping fails."""
+        referrer = JobDestination(id="tpv_dispatcher", params={"tpv_explain_on_failure": True})
+        with patch.object(gateway.log, "warning") as mock_warning:
+            with self.assertRaises(JobMappingException):
+                self._call_gateway("unschedulable_tool", referrer=referrer)
+            mock_warning.assert_called_once()
+            logged_trace = mock_warning.call_args[0][1]
+            self.assertIn("TPV SCHEDULING DECISION TRACE", logged_trace)
+            self.assertIn("No destinations", logged_trace)
+
+    def test_no_log_on_successful_mapping(self):
+        """No warning is logged when tpv_explain_on_failure=true but mapping succeeds."""
+        referrer = JobDestination(id="tpv_dispatcher", params={"tpv_explain_on_failure": True})
+        with patch.object(gateway.log, "warning") as mock_warning:
+            destination = self._call_gateway("bwa", referrer=referrer)
+            self.assertIsNotNone(destination)
+            mock_warning.assert_not_called()
+
+    def test_explicit_collector_not_logged_by_gateway(self):
+        """When an explicit explain_collector is passed (dry-run path), the gateway does not log on failure."""
+        collector = ExplainCollector()
+        with patch.object(gateway.log, "warning") as mock_warning:
+            with self.assertRaises(JobMappingException):
+                self._call_gateway("unschedulable_tool", explain_collector=collector)
+            mock_warning.assert_not_called()
+        self.assertTrue(len(collector.steps) > 0)

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -1,6 +1,8 @@
+import logging
 import os
 import unittest
-from unittest.mock import MagicMock, patch
+from contextlib import contextmanager
+from unittest.mock import MagicMock
 
 import yaml
 from galaxy.jobs import JobDestination
@@ -501,6 +503,27 @@ class TestDryRunExplain(unittest.TestCase):
         self.assertIsNone(runner.tool)
 
 
+@contextmanager
+def _capture_logs(logger_name, level=logging.WARNING):
+    """Capture log records while keeping propagation enabled so --log-cli-level shows them."""
+    records = []
+
+    class _Handler(logging.Handler):
+        def emit(self, record):
+            records.append(record)
+
+    logger = logging.getLogger(logger_name)
+    handler = _Handler(level)
+    old_level = logger.level
+    logger.setLevel(level)
+    logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(old_level)
+
+
 class TestGatewayExplainOnFailure(unittest.TestCase):
     """Tests for the tpv_explain_on_failure gateway config option."""
 
@@ -523,35 +546,37 @@ class TestGatewayExplainOnFailure(unittest.TestCase):
 
     def test_no_log_when_param_not_set(self):
         """No warning is logged on failure when tpv_explain_on_failure is not configured."""
-        with patch.object(gateway.log, "warning") as mock_warning:
+        with _capture_logs("tpv.rules.gateway") as records:
             with self.assertRaises(JobMappingException):
                 self._call_gateway("unschedulable_tool")
-            mock_warning.assert_not_called()
+        self.assertEqual(len(records), 0)
 
     def test_logs_trace_on_mapping_failure(self):
         """A WARNING containing the scheduling trace is logged when tpv_explain_on_failure=true and mapping fails."""
         referrer = JobDestination(id="tpv_dispatcher", params={"tpv_explain_on_failure": True})
-        with patch.object(gateway.log, "warning") as mock_warning:
+        with _capture_logs("tpv.rules.gateway") as records:
             with self.assertRaises(JobMappingException):
                 self._call_gateway("unschedulable_tool", referrer=referrer)
-            mock_warning.assert_called_once()
-            logged_trace = mock_warning.call_args[0][1]
-            self.assertIn("TPV SCHEDULING DECISION TRACE", logged_trace)
-            self.assertIn("No destinations", logged_trace)
+        self.assertEqual(len(records), 1)
+        trace = records[0].getMessage()
+        self.assertIn("TPV SCHEDULING DECISION TRACE", trace)
+        self.assertIn("REJECTED", trace)
+        self.assertIn("tag mismatch", trace)
+        self.assertIn("No destinations", trace)
 
     def test_no_log_on_successful_mapping(self):
         """No warning is logged when tpv_explain_on_failure=true but mapping succeeds."""
         referrer = JobDestination(id="tpv_dispatcher", params={"tpv_explain_on_failure": True})
-        with patch.object(gateway.log, "warning") as mock_warning:
+        with _capture_logs("tpv.rules.gateway") as records:
             destination = self._call_gateway("bwa", referrer=referrer)
-            self.assertIsNotNone(destination)
-            mock_warning.assert_not_called()
+        self.assertIsNotNone(destination)
+        self.assertEqual(len(records), 0)
 
     def test_explicit_collector_not_logged_by_gateway(self):
         """When an explicit explain_collector is passed (dry-run path), the gateway does not log on failure."""
         collector = ExplainCollector()
-        with patch.object(gateway.log, "warning") as mock_warning:
+        with _capture_logs("tpv.rules.gateway") as records:
             with self.assertRaises(JobMappingException):
                 self._call_gateway("unschedulable_tool", explain_collector=collector)
-            mock_warning.assert_not_called()
+        self.assertEqual(len(records), 0)
         self.assertTrue(len(collector.steps) > 0)

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -167,4 +167,5 @@ def get_dataset_attributes(
             "size": get_dataset_size(i.dataset.dataset),
         }
         for i in datasets or {}
+        if i.dataset
     }

--- a/tpv/rules/gateway.py
+++ b/tpv/rules/gateway.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 
 from galaxy.app import UniverseApplication
 from galaxy.jobs import JobDestination, JobWrapper
+from galaxy.jobs.mapper import JobMappingException
 from galaxy.model import Job
 from galaxy.model import User as GalaxyUser
 from galaxy.tools import Tool as GalaxyTool
@@ -117,18 +118,26 @@ def map_tool_to_destination(
         raise ValueError("One of tpv_configs or tpv_config_files must be specified in execution environment.")
     referrer_id = referrer.id if referrer else None
     destination_mapper = lock_and_load_mapper(app, referrer_id or "tpv_dispatcher", resolved_tpv_configs)
-    if explain_collector:
+    explain_on_failure = bool(referrer.params.get("tpv_explain_on_failure", False)) if referrer else False
+    auto_collect = explain_collector is None and explain_on_failure
+    active_collector = explain_collector or (ExplainCollector() if auto_collect else None)
+    if active_collector:
         configs_list = listify(resolved_tpv_configs)
         for config_source in configs_list:
             source_name = config_source if isinstance(config_source, str) else "<inline config>"
-            explain_collector.add_step(ExplainPhase.CONFIG_LOADING, f"Loaded config: {source_name}")
-    return destination_mapper.map_to_destination(
-        app,
-        tool,
-        user,
-        job,
-        job_wrapper,
-        resource_params,
-        workflow_invocation_uuid,
-        explain_collector=explain_collector,
-    )
+            active_collector.add_step(ExplainPhase.CONFIG_LOADING, f"Loaded config: {source_name}")
+    try:
+        return destination_mapper.map_to_destination(
+            app,
+            tool,
+            user,
+            job,
+            job_wrapper,
+            resource_params,
+            workflow_invocation_uuid,
+            explain_collector=active_collector,
+        )
+    except JobMappingException:
+        if auto_collect:
+            log.warning("Job mapping failed. TPV scheduling trace:\n%s", active_collector.render())
+        raise

--- a/tpv/rules/gateway.py
+++ b/tpv/rules/gateway.py
@@ -139,5 +139,6 @@ def map_tool_to_destination(
         )
     except JobMappingException:
         if log_on_failure:
+            assert collector is not None
             log.warning("Job mapping failed. TPV scheduling trace:\n%s", collector.render())
         raise

--- a/tpv/rules/gateway.py
+++ b/tpv/rules/gateway.py
@@ -119,13 +119,13 @@ def map_tool_to_destination(
     referrer_id = referrer.id if referrer else None
     destination_mapper = lock_and_load_mapper(app, referrer_id or "tpv_dispatcher", resolved_tpv_configs)
     explain_on_failure = bool(referrer.params.get("tpv_explain_on_failure", False)) if referrer else False
-    auto_collect = explain_collector is None and explain_on_failure
-    active_collector = explain_collector or (ExplainCollector() if auto_collect else None)
-    if active_collector:
+    log_on_failure = explain_collector is None and explain_on_failure
+    collector = explain_collector or (ExplainCollector() if log_on_failure else None)
+    if collector:
         configs_list = listify(resolved_tpv_configs)
         for config_source in configs_list:
             source_name = config_source if isinstance(config_source, str) else "<inline config>"
-            active_collector.add_step(ExplainPhase.CONFIG_LOADING, f"Loaded config: {source_name}")
+            collector.add_step(ExplainPhase.CONFIG_LOADING, f"Loaded config: {source_name}")
     try:
         return destination_mapper.map_to_destination(
             app,
@@ -135,9 +135,9 @@ def map_tool_to_destination(
             job_wrapper,
             resource_params,
             workflow_invocation_uuid,
-            explain_collector=active_collector,
+            explain_collector=collector,
         )
     except JobMappingException:
-        if auto_collect:
-            log.warning("Job mapping failed. TPV scheduling trace:\n%s", active_collector.render())
+        if log_on_failure:
+            log.warning("Job mapping failed. TPV scheduling trace:\n%s", collector.render())
         raise


### PR DESCRIPTION
When TPV raises a JobMappingException during live Galaxy job routing, the scheduling decision trace is silently discarded. This makes it hard to diagnose why a job couldn't be routed. Admins currently have to reproduce the failure manually with tpv dry-run --explain.

This PR adds a tpv_explain_on_failure param to the tpv_dispatcher execution environment. When enabled, TPV automatically collects and logs the full scheduling trace as a WARNING whenever mapping fails.

https://github.com/pauldg/total-perspective-vortex/blob/c9e370b640c570721a5d09351d9644ca0c8aa202/tpv/rules/gateway.py#L120-L123

collector is non-None whenever explain steps should be gathered, either the dry-runner passed one in, or tpv_explain_on_failure is enabled. log_on_failure distinguishes is only True in the live-Galaxy case, so the gateway logs the trace on failure. In the dry-run case the caller owns the collector and handles output itself.



Configuration:
```
# job_conf.yml
environments:
  tpv_dispatcher:
    runner: dynamic
    type: python
    function: map_tool_to_destination
    tpv_explain_on_failure: true
    tpv_config_files: ...
```

Log output on failure:
```
WARNING tpv.rules.gateway - Job mapping failed. TPV scheduling trace:
========================================================================
TPV SCHEDULING DECISION TRACE
========================================================================
--- Entity Matching ---
  [8] Tool 'salmon/1.10.1': matched entity 'salmon/.*'
--- Destination Matching ---
  [19] condor_tpv: REJECTED
         tag mismatch - entity tags: require=['conda'] ...
  [20] pulsar_be_tpv: REJECTED
         mem 70 exceeds max_accepted_mem 15
--- Final Result ---
  [N] No destinations are available to fulfill request: salmon/.*
```

Disabled by default.