### PR TITLE
Add `weighted_choice` helper for weighted random selection in TPV configs

### DIFF
--- a/docs/topics/advanced_topics.rst
+++ b/docs/topics/advanced_topics.rst
@@ -357,9 +357,10 @@ that can be used in rules, rank functions, params, and other code blocks.
 | ``sampling(destinations)``         | destination's optional ``params.weight`` value. Used in rank functions   |
 |                                    | to break ties or provide a fallback when load-based ranking fails.       |
 +------------------------------------+--------------------------------------------------------------------------+
-| ``helpers.weighted_choice(items)`` | Selects a single value from a weighted pool of ``{value, weight}`` dicts |
-|                                    | and returns the chosen ``value`` string. Generic over the meaning of     |
-|                                    | ``value``; primary use case is distributing jobs across multiple job     |
+| ``helpers.weighted_choice(items)`` | Selects one item from a weighted pool of ``{value, weight}`` dicts and    |
+|                                    | returns the chosen dict, mirroring ``random.choice``. Use               |
+|                                    | ``helpers.weighted_choice(items)["value"]`` when you need the underlying |
+|                                    | string. Primary use case is distributing jobs across multiple job        |
 |                                    | working directory roots. See the recipe in :doc:`tpv_by_example`.        |
 +------------------------------------+--------------------------------------------------------------------------+
 | ``helpers.input_size(job)``        | Returns the total input dataset size in GB for the given job.            |

--- a/docs/topics/advanced_topics.rst
+++ b/docs/topics/advanced_topics.rst
@@ -340,3 +340,43 @@ As this may often be too simplistic, the rank function can be overridden by spec
 rank clause. The rank clause can contain an arbitrary code block, which can do the desired sorting,
 for example by determining destination load by querying the job manager, influx statistics etc.
 The final statement in the rank clause must be the list of sorted destinations.
+
+Helper functions
+================
+TPV exposes a ``helpers`` module in the evaluation context, which provides utility functions
+that can be used in rules, rank functions, params, and other code blocks.
+
++------------------------------------+--------------------------------------------------------------------------+
+| Helper                             | Description                                                              |
++====================================+==========================================================================+
+| ``helpers.job_args_match(``        | Checks whether a dict of argument key/value pairs matches the job's      |
+| ``job, app, args)``                | input parameters. Useful for routing based on specific tool argument     |
+|                                    | values, similar to Galaxy's dynamic tool destination matching.           |
++------------------------------------+--------------------------------------------------------------------------+
+| ``helpers.weighted_random_``       | Returns a shuffled list of all destinations, weighted by each            |
+| ``sampling(destinations)``         | destination's optional ``params.weight`` value. Used in rank functions   |
+|                                    | to break ties or provide a fallback when load-based ranking fails.       |
++------------------------------------+--------------------------------------------------------------------------+
+| ``helpers.weighted_choice(items)`` | Selects a single value from a weighted pool of ``{value, weight}`` dicts |
+|                                    | and returns the chosen ``value`` string. Generic over the meaning of     |
+|                                    | ``value``; primary use case is distributing jobs across multiple job     |
+|                                    | working directory roots. See the recipe in :doc:`tpv_by_example`.        |
++------------------------------------+--------------------------------------------------------------------------+
+| ``helpers.input_size(job)``        | Returns the total input dataset size in GB for the given job.            |
++------------------------------------+--------------------------------------------------------------------------+
+| ``helpers.concurrent_job_count_``  | Returns the number of queued/running jobs for the given tool (and        |
+| ``for_tool(app, tool, user)``      | optional user). Useful for limiting concurrent executions per tool.      |
++------------------------------------+--------------------------------------------------------------------------+
+| ``helpers.tag_values_match(``      | Returns ``True`` if an entity has all ``match_tag_values`` tags and none |
+| ``entity, match_tag_values,``      | of the ``exclude_tag_values`` tags.                                      |
+| ``exclude_tag_values)``            |                                                                          |
++------------------------------------+--------------------------------------------------------------------------+
+| ``helpers.tool_version_eq/lte/``   | Compare the tool's version against a given version string using the      |
+| ``lt/gte/gt(tool, version)``       | specified comparator.                                                    |
++------------------------------------+--------------------------------------------------------------------------+
+| ``helpers.get_tool_resource_``     | Extracts a specific resource field (cores, mem, gpus) from a tool's      |
+| ``field(tool, field_name)``        | resource requirements.                                                   |
++------------------------------------+--------------------------------------------------------------------------+
+| ``helpers.get_dataset_``           | Returns a dict mapping dataset IDs to their object store ID and file     |
+| ``attributes(datasets)``           | size in bytes.                                                           |
++------------------------------------+--------------------------------------------------------------------------+

--- a/docs/topics/tpv_by_example.rst
+++ b/docs/topics/tpv_by_example.rst
@@ -608,3 +608,47 @@ property.
      slurm:
        runner: slurm
        destination_name_override: "my-dest-with-{cores}-cores-{mem}-mem"
+
+Selecting a job working directory from a weighted pool
+------------------------------------------------------
+The ``helpers.weighted_choice`` helper selects a single value from a weighted
+pool of ``{value, weight}`` dictionaries.  One of the interesting use cases is distributing
+jobs across multiple job working directory roots with configurable weights —
+useful when you have multiple storage paths for job working directories and
+want to steer the majority of jobs to a particular path while keeping a fallback
+available.  The helper is generic over the meaning of ``value``, so any
+string-valued pool (cache paths, runner URLs, etc.) works the same way.
+
+.. code-block:: yaml
+   :linenos:
+   :emphasize-lines: 4-9,14
+
+   global:
+     context:
+       jwd_pool:
+         - value: /fast/jobs
+           weight: 3
+         - value: /slow/jobs
+           weight: 1
+
+   tools:
+     default:
+       cores: 2
+       mem: 4
+       params:
+         job_working_directory: "{helpers.weighted_choice(jwd_pool)}"
+
+In this example, the ``jwd_pool`` context variable is a list of dictionaries,
+each with a ``value`` (the string to use) and an optional ``weight`` (defaults
+to 1).  ``helpers.weighted_choice`` returns the ``value`` of a randomly selected
+item, weighted by the ``weight`` value.  With the weights above, ``/fast/jobs``
+is selected three times as often as ``/slow/jobs``.
+
+To drain a directory, set its weight to ``0``.  If all weights are zero, the
+helper falls back to an unweighted random selection so the configuration always
+resolves.
+
+This recipe requires Galaxy's ``job_working_directory`` job-concern support
+(Galaxy PR :issue:`23133` / :issue:`15616` / :issue:`20062`).  Without that
+change, the param is still set by TPV but Galaxy will use the object-store
+derived path instead.

--- a/docs/topics/tpv_by_example.rst
+++ b/docs/topics/tpv_by_example.rst
@@ -636,13 +636,13 @@ string-valued pool (cache paths, runner URLs, etc.) works the same way.
        cores: 2
        mem: 4
        params:
-         job_working_directory: "{helpers.weighted_choice(jwd_pool)}"
+         job_working_directory: "{helpers.weighted_choice(jwd_pool)['value']}"
 
 In this example, the ``jwd_pool`` context variable is a list of dictionaries,
 each with a ``value`` (the string to use) and an optional ``weight`` (defaults
-to 1).  ``helpers.weighted_choice`` returns the ``value`` of a randomly selected
-item, weighted by the ``weight`` value.  With the weights above, ``/fast/jobs``
-is selected three times as often as ``/slow/jobs``.
+to 1).  ``helpers.weighted_choice`` returns the selected dictionary item; the
+``['value']`` field is used to populate the job working directory.  With the
+weights above, ``/fast/jobs`` is selected three times as often as ``/slow/jobs``.
 
 To drain a directory, set its weight to ``0``.  If all weights are zero, the
 helper falls back to an unweighted random selection so the configuration always

--- a/tests/fixtures/mapping-weighted-choice.yml
+++ b/tests/fixtures/mapping-weighted-choice.yml
@@ -12,7 +12,7 @@ tools:
     cores: 2
     mem: cores * 3
     params:
-      job_working_directory: "{helpers.weighted_choice(jwd_pool)}"
+      job_working_directory: "{helpers.weighted_choice(jwd_pool)['value']}"
     scheduling:
       require: []
       prefer:

--- a/tests/fixtures/mapping-weighted-choice.yml
+++ b/tests/fixtures/mapping-weighted-choice.yml
@@ -1,0 +1,34 @@
+global:
+  default_inherits: default
+  context:
+    jwd_pool:
+      - value: /fast/jobs
+        weight: 3
+      - value: /slow/jobs
+        weight: 1
+
+tools:
+  default:
+    cores: 2
+    mem: cores * 3
+    params:
+      job_working_directory: "{helpers.weighted_choice(jwd_pool)}"
+    scheduling:
+      require: []
+      prefer:
+        - general
+      accept:
+      reject: []
+
+  bwa:
+    cores: 4
+    mem: cores * 4
+
+destinations:
+  local:
+    runner: local
+    max_accepted_cores: 16
+    max_accepted_mem: 64
+    scheduling:
+      prefer:
+        - general

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -11,6 +11,7 @@ from tpv.core.helpers import (
     get_input_datasets,
     get_input_size,
     input_size,
+    weighted_choice,
     weighted_random_sampling,
 )
 
@@ -161,3 +162,103 @@ class TestHelpers(unittest.TestCase):
         self.assertEqual(result, sampled_destinations)
         choices_mock.assert_called_once_with(destinations, weights=[5, 1, 1], k=3)
         sample_mock.assert_not_called()
+
+    def test_weighted_choice_without_weights_uses_unweighted_choice(self):
+        """When no item defines weight, use unweighted random choice."""
+        items = [
+            {"value": "/fast/jobs"},
+            {"value": "/slow/jobs"},
+            {"value": "/backup/jobs", "foo": "bar"},
+        ]
+
+        with patch("tpv.core.helpers.random.choice", return_value=items[1]) as choice_mock:
+            with patch("tpv.core.helpers.random.choices") as choices_mock:
+                result = weighted_choice(items)
+
+        self.assertEqual(result, "/slow/jobs")
+        choice_mock.assert_called_once_with(items)
+        choices_mock.assert_not_called()
+
+    def test_weighted_choice_with_weights_uses_weighted_choices(self):
+        """When any item defines weight, use weighted random choices."""
+        items = [
+            {"value": "/fast/jobs", "weight": 3},
+            {"value": "/slow/jobs"},
+            {"value": "/backup/jobs"},
+        ]
+        with patch("tpv.core.helpers.random.choices", return_value=[items[0]]) as choices_mock:
+            with patch("tpv.core.helpers.random.choice") as choice_mock:
+                result = weighted_choice(items)
+
+        self.assertEqual(result, "/fast/jobs")
+        choices_mock.assert_called_once_with(items, weights=[3, 1, 1], k=1)
+        choice_mock.assert_not_called()
+
+    def test_weighted_choice_missing_weight_defaults_to_one(self):
+        """Items without a weight key should default to weight 1."""
+        items = [
+            {"value": "/a", "weight": 5},
+            {"value": "/b"},
+            {"value": "/c"},
+        ]
+        with patch("tpv.core.helpers.random.choices", return_value=[items[1]]) as choices_mock:
+            weighted_choice(items)
+
+        choices_mock.assert_called_once_with(items, weights=[5, 1, 1], k=1)
+
+    def test_weighted_choice_zero_weights_falls_back_to_unweighted(self):
+        """If all weights are zero or negative, fall back to unweighted choice."""
+        items = [
+            {"value": "/drained/jobs", "weight": 0},
+            {"value": "/also-drained/jobs", "weight": -1},
+        ]
+        with patch("tpv.core.helpers.random.choice", return_value=items[0]) as choice_mock:
+            with patch("tpv.core.helpers.random.choices") as choices_mock:
+                result = weighted_choice(items)
+
+        self.assertEqual(result, "/drained/jobs")
+        choice_mock.assert_called_once_with(items)
+        choices_mock.assert_not_called()
+
+    def test_weighted_choice_negative_weight_is_clamped_to_zero(self):
+        """A negative weight is clamped to 0 while positive weights are preserved."""
+        items = [
+            {"value": "/a", "weight": 5},
+            {"value": "/b", "weight": -3},
+        ]
+        with patch("tpv.core.helpers.random.choices", return_value=[items[0]]) as choices_mock:
+            with patch("tpv.core.helpers.random.choice") as choice_mock:
+                weighted_choice(items)
+
+        choices_mock.assert_called_once_with(items, weights=[5, 0], k=1)
+        choice_mock.assert_not_called()
+
+    def test_weighted_choice_default_weight_keys_use_unweighted(self):
+        """If every item has weight: 1 (the default), use unweighted choice."""
+        items = [
+            {"value": "/a", "weight": 1},
+            {"value": "/b", "weight": 1},
+        ]
+        with patch("tpv.core.helpers.random.choice", return_value=items[0]) as choice_mock:
+            with patch("tpv.core.helpers.random.choices") as choices_mock:
+                weighted_choice(items)
+
+        choice_mock.assert_called_once_with(items)
+        choices_mock.assert_not_called()
+
+    def test_weighted_choice_empty_list_raises_value_error(self):
+        """An empty list should raise ValueError."""
+        with self.assertRaises(ValueError):
+            weighted_choice([])
+
+    def test_weighted_choice_returns_value_string(self):
+        """The helper should return the value string, not the whole dict."""
+        items = [
+            {"value": "/primary/jobs", "weight": 10},
+            {"value": "/secondary/jobs", "weight": 1},
+        ]
+        with patch("tpv.core.helpers.random.choices", return_value=[items[1]]):
+            result = weighted_choice(items)
+
+        self.assertIsInstance(result, str)
+        self.assertEqual(result, "/secondary/jobs")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -171,12 +171,12 @@ class TestHelpers(unittest.TestCase):
             {"value": "/backup/jobs", "foo": "bar"},
         ]
 
-        with patch("tpv.core.helpers.random.choice", return_value=items[1]) as choice_mock:
+        with patch("tpv.core.helpers.random.sample", return_value=[items[1]]) as sample_mock:
             with patch("tpv.core.helpers.random.choices") as choices_mock:
                 result = weighted_choice(items)
 
-        self.assertEqual(result, "/slow/jobs")
-        choice_mock.assert_called_once_with(items)
+        self.assertEqual(result, items[1])
+        sample_mock.assert_called_once_with(items, k=1)
         choices_mock.assert_not_called()
 
     def test_weighted_choice_with_weights_uses_weighted_choices(self):
@@ -187,12 +187,12 @@ class TestHelpers(unittest.TestCase):
             {"value": "/backup/jobs"},
         ]
         with patch("tpv.core.helpers.random.choices", return_value=[items[0]]) as choices_mock:
-            with patch("tpv.core.helpers.random.choice") as choice_mock:
+            with patch("tpv.core.helpers.random.sample") as sample_mock:
                 result = weighted_choice(items)
 
-        self.assertEqual(result, "/fast/jobs")
+        self.assertEqual(result, items[0])
         choices_mock.assert_called_once_with(items, weights=[3, 1, 1], k=1)
-        choice_mock.assert_not_called()
+        sample_mock.assert_not_called()
 
     def test_weighted_choice_missing_weight_defaults_to_one(self):
         """Items without a weight key should default to weight 1."""
@@ -202,22 +202,23 @@ class TestHelpers(unittest.TestCase):
             {"value": "/c"},
         ]
         with patch("tpv.core.helpers.random.choices", return_value=[items[1]]) as choices_mock:
-            weighted_choice(items)
+            result = weighted_choice(items)
 
+        self.assertEqual(result, items[1])
         choices_mock.assert_called_once_with(items, weights=[5, 1, 1], k=1)
 
     def test_weighted_choice_zero_weights_falls_back_to_unweighted(self):
-        """If all weights are zero or negative, fall back to unweighted choice."""
+        """If all weights are zero or negative, fall back to unweighted selection."""
         items = [
             {"value": "/drained/jobs", "weight": 0},
             {"value": "/also-drained/jobs", "weight": -1},
         ]
-        with patch("tpv.core.helpers.random.choice", return_value=items[0]) as choice_mock:
+        with patch("tpv.core.helpers.random.sample", return_value=[items[0]]) as sample_mock:
             with patch("tpv.core.helpers.random.choices") as choices_mock:
                 result = weighted_choice(items)
 
-        self.assertEqual(result, "/drained/jobs")
-        choice_mock.assert_called_once_with(items)
+        self.assertEqual(result, items[0])
+        sample_mock.assert_called_once_with(items, k=1)
         choices_mock.assert_not_called()
 
     def test_weighted_choice_negative_weight_is_clamped_to_zero(self):
@@ -227,11 +228,11 @@ class TestHelpers(unittest.TestCase):
             {"value": "/b", "weight": -3},
         ]
         with patch("tpv.core.helpers.random.choices", return_value=[items[0]]) as choices_mock:
-            with patch("tpv.core.helpers.random.choice") as choice_mock:
+            with patch("tpv.core.helpers.random.sample") as sample_mock:
                 weighted_choice(items)
 
         choices_mock.assert_called_once_with(items, weights=[5, 0], k=1)
-        choice_mock.assert_not_called()
+        sample_mock.assert_not_called()
 
     def test_weighted_choice_default_weight_keys_use_unweighted(self):
         """If every item has weight: 1 (the default), use unweighted choice."""
@@ -239,11 +240,11 @@ class TestHelpers(unittest.TestCase):
             {"value": "/a", "weight": 1},
             {"value": "/b", "weight": 1},
         ]
-        with patch("tpv.core.helpers.random.choice", return_value=items[0]) as choice_mock:
+        with patch("tpv.core.helpers.random.sample", return_value=[items[0]]) as sample_mock:
             with patch("tpv.core.helpers.random.choices") as choices_mock:
                 weighted_choice(items)
 
-        choice_mock.assert_called_once_with(items)
+        sample_mock.assert_called_once_with(items, k=1)
         choices_mock.assert_not_called()
 
     def test_weighted_choice_empty_list_raises_value_error(self):
@@ -251,8 +252,8 @@ class TestHelpers(unittest.TestCase):
         with self.assertRaises(ValueError):
             weighted_choice([])
 
-    def test_weighted_choice_returns_value_string(self):
-        """The helper should return the value string, not the whole dict."""
+    def test_weighted_choice_returns_selected_item(self):
+        """The helper should return the selected item, not a derived string value."""
         items = [
             {"value": "/primary/jobs", "weight": 10},
             {"value": "/secondary/jobs", "weight": 1},
@@ -260,5 +261,5 @@ class TestHelpers(unittest.TestCase):
         with patch("tpv.core.helpers.random.choices", return_value=[items[1]]):
             result = weighted_choice(items)
 
-        self.assertIsInstance(result, str)
-        self.assertEqual(result, "/secondary/jobs")
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result, items[1])

--- a/tests/test_mapper_weighted_choice.py
+++ b/tests/test_mapper_weighted_choice.py
@@ -1,0 +1,59 @@
+"""Integration tests for the weighted_choice helper in TPV config files."""
+
+import os
+import unittest
+from unittest.mock import patch
+
+from galaxy.jobs import JobDestination
+
+from tpv.commands.test import mock_galaxy
+from tpv.rules import gateway
+
+
+class TestMapperWeightedChoice(unittest.TestCase):
+
+    @staticmethod
+    def _map_to_destination(tool: mock_galaxy.Tool, user: mock_galaxy.User, tpv_config_path: str) -> JobDestination:
+        galaxy_app = mock_galaxy.App(job_conf=os.path.join(os.path.dirname(__file__), "fixtures/job_conf.yml"))
+        job = mock_galaxy.Job()
+        gateway.ACTIVE_DESTINATION_MAPPERS = {}
+        return gateway.map_tool_to_destination(galaxy_app, job, tool, user, tpv_config_files=[tpv_config_path])  # type: ignore[arg-type]
+
+    def test_weighted_choice_sets_job_working_directory_param(self) -> None:
+        """helpers.weighted_choice in a params f-string should set job_working_directory."""
+        fixture = os.path.join(
+            os.path.dirname(__file__),
+            "fixtures/mapping-weighted-choice.yml",
+        )
+        tool = mock_galaxy.Tool("bwa")
+        user = mock_galaxy.User("ford", "prefect@vortex.org")
+
+        # Patch random.choices to always return the first item (weight 3, /fast/jobs)
+        pool = [
+            {"value": "/fast/jobs", "weight": 3},
+            {"value": "/slow/jobs", "weight": 1},
+        ]
+        with patch("tpv.core.helpers.random.choices", return_value=[pool[0]]):
+            destination = self._map_to_destination(tool, user, tpv_config_path=fixture)
+
+        self.assertIn("job_working_directory", destination.params)
+        self.assertEqual(destination.params["job_working_directory"], "/fast/jobs")
+
+    def test_weighted_choice_selects_different_path_when_patched(self) -> None:
+        """When random.choices returns a different item, the param should reflect it."""
+        fixture = os.path.join(
+            os.path.dirname(__file__),
+            "fixtures/mapping-weighted-choice.yml",
+        )
+        tool = mock_galaxy.Tool("bwa")
+        user = mock_galaxy.User("ford", "prefect@vortex.org")
+
+        pool = [
+            {"value": "/fast/jobs", "weight": 3},
+            {"value": "/slow/jobs", "weight": 1},
+        ]
+        # Patch to return the second item
+        with patch("tpv.core.helpers.random.choices", return_value=[pool[1]]):
+            destination = self._map_to_destination(tool, user, tpv_config_path=fixture)
+
+        self.assertEqual(destination.params["job_working_directory"], "/slow/jobs")

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -10,7 +10,7 @@ import random
 import re
 from collections.abc import Callable
 from functools import reduce
-from typing import Any, TypeVar, TypedDict
+from typing import Any, TypedDict, TypeVar
 
 T = TypeVar("T")
 

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -10,7 +10,9 @@ import random
 import re
 from collections.abc import Callable
 from functools import reduce
-from typing import Any
+from typing import Any, TypeVar, TypedDict
+
+T = TypeVar("T")
 
 from galaxy import model
 from galaxy.app import UniverseApplication
@@ -125,14 +127,53 @@ def get_input_size(
     return total / GIGABYTES
 
 
+def _resolve_weights(items: list[T], get_weight: Callable[[T], float]) -> list[float]:
+    """Return clamped, non-negative weights for *items*.
+
+    ``get_weight`` extracts the weight from each item (defaulting to 1).
+    Negative weights are clamped to 0 so they are excluded from selection.
+    """
+    return [max(get_weight(item), 0) for item in items]
+
+
+def _has_weighted_selection(weights: list[float]) -> bool:
+    """True if *weights* warrant weighted selection: at least one non-default
+    weight and at least one positive weight."""
+    return any(w != 1 for w in weights) and any(w > 0 for w in weights)
+
+
 def weighted_random_sampling(destinations: list[Destination]) -> list[Destination]:
     if not destinations:
         return []
-    has_explicit_weight = any(d.params and "weight" in d.params for d in destinations)
-    if not has_explicit_weight:
+    weights = _resolve_weights(destinations, lambda d: d.params.get("weight", 1) if d.params else 1)
+    if not _has_weighted_selection(weights):
         return random.sample(destinations, k=len(destinations))
-    rankings = [(d.params.get("weight", 1) if d.params else 1) for d in destinations]
-    return random.choices(destinations, weights=rankings, k=len(destinations))
+    return random.choices(destinations, weights=weights, k=len(destinations))
+
+
+class WeightedItem(TypedDict, total=False):
+    value: str
+    weight: float
+
+
+def weighted_choice(items: list[WeightedItem]) -> str:
+    """Select a single ``value`` from a weighted pool of ``{value, weight}`` dicts.
+
+    ``weight`` is optional (defaults to 1); a weight of 0 or less excludes the
+    entry.  If no item defines a non-default weight, or all weights are zero,
+    an unweighted random selection is used.  Primary use case: distributing
+    jobs across multiple job working directory roots.
+
+    Raises:
+        ValueError: If *items* is empty.
+    """
+    if not items:
+        raise ValueError("weighted_choice requires a non-empty list of items")
+
+    weights = _resolve_weights(items, lambda item: item.get("weight", 1))
+    if not _has_weighted_selection(weights):
+        return random.choice(items)["value"]
+    return random.choices(items, weights=weights, k=1)[0]["value"]
 
 
 def __get_keys_from_dict(dl: Any, keys_list: list[str]) -> None:

--- a/tpv/core/helpers.py
+++ b/tpv/core/helpers.py
@@ -8,11 +8,12 @@ except ImportError:
 import operator
 import random
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from functools import reduce
-from typing import Any, TypedDict, TypeVar
+from typing import Any, TypeVar
 
 T = TypeVar("T")
+WeightedT = TypeVar("WeightedT", bound=Mapping[str, Any])
 
 from galaxy import model
 from galaxy.app import UniverseApplication
@@ -127,53 +128,38 @@ def get_input_size(
     return total / GIGABYTES
 
 
-def _resolve_weights(items: list[T], get_weight: Callable[[T], float]) -> list[float]:
-    """Return clamped, non-negative weights for *items*.
+def _weighted_draw(items: list[T], weights: list[float], k: int) -> list[T]:
+    """Draw *k* items from *items*, biased by *weights*.
 
-    ``get_weight`` extracts the weight from each item (defaulting to 1).
-    Negative weights are clamped to 0 so they are excluded from selection.
+    Negative weights are clamped to zero. If no weight deviates from the default
+    of 1, or every weight is zero, the draw is unweighted so a fully drained pool
+    still resolves instead of raising.
     """
-    return [max(get_weight(item), 0) for item in items]
-
-
-def _has_weighted_selection(weights: list[float]) -> bool:
-    """True if *weights* warrant weighted selection: at least one non-default
-    weight and at least one positive weight."""
-    return any(w != 1 for w in weights) and any(w > 0 for w in weights)
+    weights = [max(w, 0) for w in weights]
+    if any(w != 1 for w in weights) and any(w > 0 for w in weights):
+        return random.choices(items, weights=weights, k=k)
+    return random.sample(items, k=k)
 
 
 def weighted_random_sampling(destinations: list[Destination]) -> list[Destination]:
     if not destinations:
         return []
-    weights = _resolve_weights(destinations, lambda d: d.params.get("weight", 1) if d.params else 1)
-    if not _has_weighted_selection(weights):
-        return random.sample(destinations, k=len(destinations))
-    return random.choices(destinations, weights=weights, k=len(destinations))
+    weights = [(d.params or {}).get("weight", 1) for d in destinations]
+    return _weighted_draw(destinations, weights, k=len(destinations))
 
 
-class WeightedItem(TypedDict, total=False):
-    value: str
-    weight: float
+def weighted_choice(items: list[WeightedT]) -> WeightedT:
+    """Select one item from *items*, biased by each item's optional ``weight``.
 
-
-def weighted_choice(items: list[WeightedItem]) -> str:
-    """Select a single ``value`` from a weighted pool of ``{value, weight}`` dicts.
-
-    ``weight`` is optional (defaults to 1); a weight of 0 or less excludes the
-    entry.  If no item defines a non-default weight, or all weights are zero,
-    an unweighted random selection is used.  Primary use case: distributing
-    jobs across multiple job working directory roots.
+    Returns the item itself, mirroring ``random.choice``. Subscript it for the
+    field you need, e.g. ``weighted_choice(jwd_pool)["value"]``.
 
     Raises:
         ValueError: If *items* is empty.
     """
     if not items:
         raise ValueError("weighted_choice requires a non-empty list of items")
-
-    weights = _resolve_weights(items, lambda item: item.get("weight", 1))
-    if not _has_weighted_selection(weights):
-        return random.choice(items)["value"]
-    return random.choices(items, weights=weights, k=1)[0]["value"]
+    return _weighted_draw(items, [item.get("weight", 1) for item in items], k=1)[0]
 
 
 def __get_keys_from_dict(dl: Any, keys_list: list[str]) -> None:


### PR DESCRIPTION
Adds a new `helpers.weighted_choice(items)` function to the TPV evaluation context, enabling weighted random selection of string values from a pool of `{value, weight}` dictionaries.

## Problem

Users with multiple storage paths (e.g., job working directory roots) need a way to distribute jobs across them with configurable weights — steering most jobs to a particular path while keeping a fallback available, or draining a path by setting its weight to 0.

## Changes

### Core (`tpv/core/helpers.py`)

- **`weighted_choice(items)`** — selects a single `value` from a weighted pool of dicts. Falls back to unweighted random selection if no non-default weights are defined or all weights are zero.
- **`_resolve_weights()`** and **`_has_weighted_selection()`** — shared helpers for weight resolution and detection.
- **`weighted_random_sampling()`** — refactored to reuse the shared weight helpers, reducing duplication.

### Documentation

- **`docs/topics/tpv_by_example.rst`** — new recipe: *"Selecting a job working directory from a weighted pool"* with a full YAML example.
- **`docs/topics/advanced_topics.rst`** — new *Helper functions* reference table documenting all exposed helpers (`weighted_choice`, `weighted_random_sampling`, `job_args_match`, `input_size`, etc.).

### Tests

- **`tests/test_helpers.py`** — 8 unit tests covering unweighted fallback, weighted selection, default weights, zero/negative weights, empty list, and return type.
- **`tests/test_mapper_weighted_choice.py`** — 2 integration tests verifying `weighted_choice` works inside a params f-string and sets `job_working_directory` on the destination.
- **`tests/fixtures/mapping-weighted-choice.yml`** — mapping fixture with a `jwd_pool` context variable.

## Usage

```yaml
global:
  context:
    jwd_pool:
      - value: /fast/jobs
        weight: 3
      - value: /slow/jobs
        weight: 1

tools:
  default:
    params:
      job_working_directory: "{helpers.weighted_choice(jwd_pool)['value']}"
```

`/fast/jobs` is selected ~75% of the time. Set `weight: 0` to drain a path.

## Related

- Galaxy PR implementing `job_working_directory` job-concern support: [galaxyproject/galaxy#23133](https://github.com/galaxyproject/galaxy/pull/23133)
- Discussion on job working directory configuration: [galaxyproject/galaxy#23107](https://github.com/galaxyproject/galaxy/discussions/23107)

## Notes

- This recipe requires Galaxy's `job_working_directory` job-concern support (PR #23133). Without it, the param is set by TPV but Galaxy will use the object-store derived path instead.
- The helper is generic over the meaning of `value` — any string-valued pool (cache paths, runner URLs, etc.) works the same way.